### PR TITLE
Correct documentation of headers event in mailparser

### DIFF
--- a/docs/extras/mailparser.md
+++ b/docs/extras/mailparser.md
@@ -127,10 +127,14 @@ sourceStream.pipe(parser);
 
 `MailParser` is a `Transform` stream in **object mode** that emits two kinds of objects via the `'data'` event:
 
-1. **`{ type: 'headers', headers: Map }`** – once, after the headers are parsed.
-2. **`{ type: 'attachment', ... }`** – for every attachment (see below).
+1. **`{ type: 'attachment', ... }`** – for every attachment (see below).
    The `content` property is a **Readable stream**.
-3. **`{ type: 'text', html, text, textAsHtml }`** – once, containing the message bodies.
+2. **`{ type: 'text', html, text, textAsHtml }`** – once, containing the message bodies.
+
+`MailParser` also emits two events for email headers:
+
+1. `'headers'` - A `Map` of header keys to their values
+2. `'headerLines'` - An `Array` of `{key: '...key...', line: '...line...'}` containing the raw lines of each header.
 
 ### Stream options {#options}
 


### PR DESCRIPTION
From looking at `@types/mailparser`, the source for `mailparser` and experimenting with using it and listening for events, I think that the documentation is outdated for how to get `headers` events. I've proposed a change that also lists the `headerLines` event which is not available in `@types/mailparser` but does seem to be emitted.